### PR TITLE
optimize the encoding and decoding for id

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -181,7 +181,7 @@
 
     // add message id
     if(msgHasId(type)) {
-      offset = encodeMsgId(id, buffer, offset);
+      offset = encodeMsgId(id, buffer, offset, idBytes);
     }
 
     // add route
@@ -217,14 +217,10 @@
 
     // parse id
     if(msgHasId(type)) {
-      var m = parseInt(bytes[offset]);
-      var i = 0;
       do{
-        var m = parseInt(bytes[offset]);
-        id = id + ((m & 0x7f) * Math.pow(2,(7*i)));
-        offset++;
-        i++;
-      }while(m >= 128);
+        var m = parseInt(bytes[offset++]);
+        id = id << 7 | ( m & 0x7f); 
+      }while(m & 0x80);
     }
 
     // parse route
@@ -295,19 +291,20 @@
     return offset + MSG_FLAG_BYTES;
   };
 
-  var encodeMsgId = function(id, buffer, offset) {
-    do{
-      var tmp = id % 128;
-      var next = Math.floor(id/128);
-
-      if(next !== 0){
-        tmp = tmp + 128;
-      }
-      buffer[offset++] = tmp;
-
-      id = next;
-    } while(id !== 0);
-
+  var encodeMsgId = function(id, buffer, offset, idBytes) {
+    switch (idBytes) {
+      // fall through
+      case 5: 
+        buffer[offset++] = ((id >> 28) & 0x7f) | 0x80;
+      case 4:
+        buffer[offset++] = ((id >> 21) & 0x7f) | 0x80;
+      case 3:
+        buffer[offset++] = ((id >> 14) & 0x7f) | 0x80;
+      case 2:
+        buffer[offset++] = ((id >> 7) & 0x7f) | 0x80;
+      case 1:
+        buffer[offset++] = id & 0x7f;
+    }
     return offset;
   };
 


### PR DESCRIPTION
利用idBytes的大小，可以去掉编码id时的循环
