### PR TITLE
Update protocol.js

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -72,7 +72,7 @@
       return buffer.toString();
     } else {
       var bytes = new ByteArray(buffer);
-      var array = [];
+      var decodeResult = '';
       var offset = 0;
       var charCode = 0;
       var end = bytes.length;
@@ -87,9 +87,9 @@
           charCode = ((bytes[offset] & 0x0f)<<12) + ((bytes[offset+1] & 0x3f)<<6) + (bytes[offset+2] & 0x3f);
           offset += 3;
         }
-        array.push(charCode);
+        decodeResult += String.fromCharCode(charCode);
       }
-      return String.fromCharCode.apply(null, array);
+      return decodeResult;
     }
   };
 


### PR DESCRIPTION
apply方法的参数中的数组的大小有限制,一般超过126k之后就会溢出,好像v8对字符串拼接做了优化,所以用+=拼接字符串,没用array.join()
