### PR TITLE
repair compatibility of Buffer with js browser client

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -34,7 +34,7 @@
    * socketio current support string
    */
   Protocol.strencode = function(str) {
-    if(ByteArray === Buffer) {
+    if(typeof Buffer !== "undefined" && ByteArray === Buffer) {
       // encoding defaults to 'utf8'
       return (new Buffer(str));
     } else {
@@ -67,7 +67,7 @@
    * return Message Object
    */
   Protocol.strdecode = function(buffer) {
-    if(ByteArray === Buffer) {
+    if(typeof Buffer !== "undefined" && ByteArray === Buffer) {
       // encoding defaults to 'utf8'
       return buffer.toString();
     } else {


### PR DESCRIPTION
js web client does not have the Buffer object, original code would cause "undefined" error in browser,
added extra condition to check the existence of Buffer object,
works well after modification, passed original test suite,
also wonder if there's a better way to check the existence of the Buffer object.
