### PR TITLE
Update protocol.js

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -276,7 +276,7 @@
   };
 
   var copyArray = function(dest, doffset, src, soffset, length) {
-    if('function' === typeof src.copy) {
+    if('function' === typeof src.copy && dest) {
       // Buffer
       src.copy(dest, doffset, soffset, soffset + length);
     } else {


### PR DESCRIPTION
在Package.decode()方法中，如果buffer是[02, 00, 00, 00],那么在第一遍循环的时候，body的值是null，调用copyArray()方法时，src.copy()的第一个参数是null，就会报错。
[02, 00, 00, 00]出现在使用chartofpomelo-websocket演示项目的初始化连接中。
环境信息：
chrome 46, node 4.1.2, pomelo 1.2.0
